### PR TITLE
Add support for automod_quarantined_guild_tag member flag

### DIFF
--- a/discord/flags.py
+++ b/discord/flags.py
@@ -2095,6 +2095,15 @@ class MemberFlags(BaseFlags):
         return 1 << 7
 
     @flag_value
+    def automod_quarantined_guild_tag(self):
+        """:class:`bool`: Returns ``True`` if the member's guild tag has been
+        blocked by AutoMod.
+
+        .. versionadded:: 2.6
+        """
+        return 1 << 10
+
+    @flag_value
     def dm_settings_upsell_acknowledged(self):
         """:class:`bool`: Returns ``True`` if the member has dismissed the DM settings upsell.
 

--- a/discord/flags.py
+++ b/discord/flags.py
@@ -2409,7 +2409,6 @@ class EmbedFlags(BaseFlags):
         return 1 << 5
 
 
-@fill_with_flags()
 class InviteFlags(BaseFlags):
     r"""Wraps up the Discord Invite flags
 


### PR DESCRIPTION
## Summary

This PR adds support for the new ``automod_quarantined_guild_tag`` member flag.
Discord-api-docs PR: discord/discord-api-docs#7699

## Checklist


- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
